### PR TITLE
Redesign roles and permissions management UI

### DIFF
--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/users/RolesView.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/users/RolesView.java
@@ -1,22 +1,12 @@
 package org.pahappa.systems.kpiTracker.views.users;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.annotation.PostConstruct;
-import javax.faces.bean.ManagedBean;
-import javax.faces.bean.SessionScoped;
-
+import com.google.common.collect.Sets;
+import com.googlecode.genericdao.search.Search;
 import lombok.Getter;
 import lombok.Setter;
 import org.pahappa.systems.kpiTracker.core.services.CustomService;
 import org.pahappa.systems.kpiTracker.core.services.impl.CustomServiceImpl;
+import org.pahappa.systems.kpiTracker.models.security.PermissionConstants;
 import org.pahappa.systems.kpiTracker.security.HyperLinks;
 import org.pahappa.systems.kpiTracker.security.UiUtils;
 import org.primefaces.model.FilterMeta;
@@ -35,8 +25,13 @@ import org.sers.webutils.server.core.utils.ApplicationContextProvider;
 import org.sers.webutils.server.shared.CustomLogger;
 import org.sers.webutils.server.shared.CustomLogger.LogSeverity;
 
-import com.google.common.collect.Sets;
-import com.googlecode.genericdao.search.Search;
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.SessionScoped;
+import javax.faces.model.SelectItem;
+import javax.faces.model.SelectItemGroup;
+import java.io.IOException;
+import java.util.*;
 
 @ManagedBean(name = "rolesView")
 @Getter
@@ -53,12 +48,93 @@ public class RolesView extends PaginatedTableView<Role, RolesView, RolesView> {
 	private String searchTerm;
 	private Role selectedRole;
 	private Set<Permission> permissionsList = new HashSet<Permission>();
-	private Set<Permission> selectedPermissionsList = new HashSet<Permission>();
+	private Set<Permission> selectedPermissions = new HashSet<Permission>(); // Changed from selectedPermissionsList
 	private Search search;
 	private Date startDate, endDate;
 	private List<SearchField> searchFields;
 	private SortField selectedSortField = new SortField("dateCreated", "dateCreated", true);
 
+	// New fields from PermissionsView
+	private static final Map<String, String> PERMISSION_CATEGORY_MAP = new HashMap<>();
+	private List<SelectItem> groupedPermissions;
+
+	static {
+		// Initialize the map to group permission names by category
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_API_USER, "General");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_WEB_ACCESS, "General");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_CREATE_USERS, "User Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_READ_VIEW_USERS, "User Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_UPDATE_USER, "User Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_DEACTIVATE_REACTIVATE_USER, "User Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_BULK_IMPORT_USERS, "User Management");
+
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_CREATE_ROLE, "Role Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_READ_VIEW_ROLES, "Role Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_UPDATE_ROLE, "Role Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_DELETE_ROLE, "Role Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_ASSIGN_ROLES_TO_USER, "Role Management");
+
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_CREATE_DEPARTMENT, "Department Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_VIEW_DEPARTMENTS, "Department Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_UPDATE_DEPARTMENT, "Department Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_DELETE_DEPARTMENT, "Department Management");
+
+		// ====================== Team Management Permissions ======================
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_CREATE_TEAM, "Team Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_READ_VIEW_TEAM, "Team Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_UPDATE_TEAM, "Team Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_DEACTIVATE_TEAM, "Team Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_DELETE_TEAM, "Team Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_VIEW_TEAMS_PAGE, "Team Management");
+
+		// ====================== Goal Management Permissions ======================
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_ADD_GOAL, "Goal Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_VIEW_GOAL, "Goal Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_UPDATE_GOAL, "Goal Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_DELETE_GOAL, "Goal Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_APPROVE_GOAL, "Goal Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_REQUEST_CHANGES_FOR_GOAL, "Goal Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_REJECT_GOAL, "Goal Management");
+
+		// ====================== Key Performance Indicator (KPI) Management Permissions ======================
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_CREATE_KPIS, "Key Performance Indicator (KPI) Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_VIEW_KPIS, "Key Performance Indicator (KPI) Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_UPDATE_KPIS, "Key Performance Indicator (KPI) Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_DELETE_KPIS, "Key Performance Indicator (KPI) Management");
+
+		// ====================== Goal Activity Management Permissions ======================
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_ATTACH_NEW_ACTIVITIES, "Goal Activity Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_EDIT_EXISTING_ACTIVITIES, "Goal Activity Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_DELETE_EXISTING_ACTIVITIES, "Goal Activity Management");
+
+		// ====================== Organization Fit Survey Management Permissions ======================
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_CREATE_SURVEY_CATEGORY, "Organization Fit Survey Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_CREATE_SURVEY_QUESTION, "Organization Fit Survey Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_VIEW_SURVEY, "Organization Fit Survey Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_UPDATE_SURVEY_CATEGORY, "Organization Fit Survey Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_UPDATE_SURVEY_QUESTION, "Organization Fit Survey Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_DELETE_SURVEY_QUESTION, "Organization Fit Survey Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_REVIEW_ORGFIT_CATEGORY, "Organization Fit Survey Management");
+
+		// ====================== Performance Tracking and Reporting Permissions ======================
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_VIEW_ALL_PERFORMANCE_SCORES, "Performance Tracking and Reporting");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_VIEW_MANAGER_PERFORMANCE_SCORES, "Performance Tracking and Reporting");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_VIEW_SELF_PERFORMANCE_SCORE, "Performance Tracking and Reporting");
+
+
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_CREATE_REWARD, "Reward Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_READ_VIEW_REWARD, "Reward Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_UPDATE_REWARD, "Reward Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_DELETE_REWARD, "Reward Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_VIEW_SELF_REWARDS, "Reward Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_VIEW_MANAGER_REWARDS, "Reward Management");
+
+
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_CREATE_PIP, "PIP Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_READ_VIEW_PIP, "PIP Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_UPDATE_PIP, "PIP Management");
+		PERMISSION_CATEGORY_MAP.put(PermissionConstants.PERM_DELETE_PIP, "PIP Management");
+	}
 
 	@PostConstruct
 	public void init() {
@@ -66,11 +142,40 @@ public class RolesView extends PaginatedTableView<Role, RolesView, RolesView> {
 		this.permissionService = ApplicationContextProvider.getBean(PermissionService.class);
 		this.customService = ApplicationContextProvider.getBean(CustomService.class);
 
-		this.permissionsList = Sets.newHashSet(customService.getPermissions(new Search().addSortAsc("name"), 0, 0));
+		// Removed permissionsList as it's not directly used for display in the new design
+		// this.permissionsList = Sets.newHashSet(customService.getPermissions(new Search().addSortAsc("name"), 0, 0));
+
 		this.searchFields = Arrays.asList(
 				new SearchField[] { new SearchField("Name", "name"), new SearchField("Description", "description") });
 		super.setMaximumresultsPerpage(10);
 		reloadFilterReset();
+
+		// Initialize grouped permissions for the display
+		List<Permission> allPermissions = permissionService.getPermissions();
+		if (allPermissions != null) {
+			generateGroupedPermissions(allPermissions);
+		}
+	}
+
+	private void generateGroupedPermissions(List<Permission> permissions) {
+		Map<String, List<SelectItem>> categorizedItems = new LinkedHashMap<>();
+		for (Permission perm : permissions) {
+			String category = PERMISSION_CATEGORY_MAP.get(perm.getName());
+			if (category == null) {
+				category = "General";
+			}
+			if (!categorizedItems.containsKey(category)) {
+				categorizedItems.put(category, new ArrayList<>());
+			}
+			categorizedItems.get(category).add(new SelectItem(perm, perm.getName()));
+		}
+
+		groupedPermissions = new ArrayList<>();
+		for (Map.Entry<String, List<SelectItem>> entry : categorizedItems.entrySet()) {
+			SelectItemGroup group = new SelectItemGroup(entry.getKey());
+			group.setSelectItems(entry.getValue().toArray(new SelectItem[0]));
+			groupedPermissions.add(group);
+		}
 	}
 
 	@Override
@@ -106,12 +211,15 @@ public class RolesView extends PaginatedTableView<Role, RolesView, RolesView> {
 		return null;
 	}
 
-	public void saveSelectedRole() throws ValidationFailedException {
-		System.err.println("------saving role---------" + this.selectedRole);
+	public void saveSelectedRolePermissions() { // Renamed method
 		try {
-			this.selectedRole.setPermissions(this.selectedPermissionsList);
-			roleService.saveRole(this.selectedRole);
-			UiUtils.showMessageBox("Action Success!", "Role updated");
+			if (selectedRole != null) {
+				selectedRole.setPermissions(this.selectedPermissions);
+				roleService.saveRole(this.selectedRole);
+				UiUtils.showMessageBox("Action Success!", "Permissions assigned to role successfully.");
+			} else {
+				UiUtils.showMessageBox("Error", "Please select a role.");
+			}
 		} catch (Exception e) {
 			e.printStackTrace();
 			UiUtils.showMessageBox("Action Failed!", e.getMessage());
@@ -122,6 +230,7 @@ public class RolesView extends PaginatedTableView<Role, RolesView, RolesView> {
 		try {
 			customService.deleteRole(role);
 			UiUtils.showMessageBox("Action Success!", "Role deleted");
+			reloadFilterReset(); // Refresh the roles list
 		} catch (Exception e) {
 			e.printStackTrace();
 			UiUtils.showMessageBox("Action Failed!", e.getMessage());
@@ -130,17 +239,20 @@ public class RolesView extends PaginatedTableView<Role, RolesView, RolesView> {
 
 	public void loadSelectedRole(Role role) {
 		if (role != null) {
-			System.err.println("------fetched roles---------" + role.getPermissions());
 			this.selectedRole = role;
-			this.selectedPermissionsList = new HashSet<Permission>(role.getPermissions());
+			// Ensure selectedPermissions is not null
+			this.selectedPermissions = role.getPermissions() != null ? new HashSet<>(role.getPermissions()) : new HashSet<>();
 		} else {
-			System.err.println("------New role---------");
-			this.selectedPermissionsList = new HashSet<Permission>();
+			this.selectedPermissions = new HashSet<>();
 			this.selectedRole = new Role();
 		}
 	}
 
-	public String redirectToPermissionsView() throws IOException {
-		return HyperLinks.PERMISSION_VIEW;
+
+
+	public void displaySelectedPermissions() {
+		for (Permission permission : selectedPermissions) {
+			System.out.println("Selected Permission: " + permission.getName());
+		}
 	}
 }

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/californiatemplate/sidebar.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/californiatemplate/sidebar.xhtml
@@ -64,17 +64,13 @@
                     <p:menuitem id="department" value="Department" icon="pi pi-fw pi-sitemap"
                         outcome="/pages/department/DepartmentView" />
 
-                    <p:submenu id="usersandroles" label="UsersandRoles" icon="pi pi-fw pi-users">
+                    <p:submenu id="usersandroles" label="Users &amp; Roles" icon="pi pi-fw pi-users">
 
                         <p:menuitem id="users" value="Users Management" icon="pi pi-fw pi-user"
                             outcome="/pages/users/UsersView" />
 
-                        <p:menuitem id="roles" value="Roles " icon="fa fa-key" outcome="/pages/roles/RolesView" />
-                        <p:menuitem id="permmissions" value="Permissions" icon="fa fa-key"
-                            outcome="/pages/permissions/Permissions" />
+                        <p:menuitem id="roles" value="Roles &amp; Permissions " icon="fa fa-key" outcome="/pages/roles/RolesView" />
 
-                        <p:menuitem id="demo" value="Demo" icon="fa fa-wrench"
-                            outcome="/pages/registerUser/RegisterUser" />
                     </p:submenu>
 
 

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/roles/RoleFormDialog.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/roles/RoleFormDialog.xhtml
@@ -18,7 +18,7 @@
                 <div class="p-col-12 p-md-6">
                     <h5>Name</h5>
                     <div class="ui-inputgroup">
-                        <p:inputText value="#{roleFormDialog.model.name}"
+                        <p:inputText id="extended" value="#{roleFormDialog.model.name}"
                                      required="true" />
                     </div>
                 </div>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/roles/RolesView.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/roles/RolesView.xhtml
@@ -6,127 +6,87 @@
                 template="/pages/californiatemplate/template.xhtml">
 
     <ui:define name="content">
-        <h:form id="rolesView" enctype="multipart/form-data">
-            <div class="p-grid ">
-                <div class="p-col-12">
+        <h:form id="rolesPermissionsForm" enctype="multipart/form-data">
+            <p:growl id="messages" showDetail="true" />
+
+            <div class="p-grid">
+                <!-- Left Panel: Roles List -->
+                <div class="p-col-12 p-md-4">
                     <div class="card">
-                        <p:growl id="messages" showDetail="true" />
-                        <div class="p-d-flex p-jc-between" style="margin: 5px">
-                            <div>
-                                <p:inputText id="searchTerm" required="false"
-                                             placeholder="Search for roles..."
-                                             onkeyup="#{rolesView.reloadFilterReset()}"
-                                             value="#{rolesView.searchTerm}">
-                                    <p:ajax event="keyup" update=":rolesView:rolesTable"
-                                            listener="#{rolesView.reloadFilterReset()}" />
-                                </p:inputText>
-                            </div>
-                            <div>
-                                <p:commandButton icon="fa fa-search"
-                                                 styleClass="p-mr-2 p-mb-2 primary-button" id="searchBtn"
-                                                 actionListener="#{rolesView.reloadFilterReset()}"
-                                                 update="rolesView" value="Search">
-                                </p:commandButton>
-                            </div>
+                        <div class="p-d-flex p-jc-between p-ai-center" style="margin-bottom: 10px;">
+                            <h3 style="font-weight: bold;">Roles (#{rolesView.totalRecords})</h3>
+                            <p:commandButton value="Create New Role" icon="fa fa-plus"
+                                             styleClass="ui-button-success" process="@this"
+                                             actionListener="#{roleFormDialog.show}">
+                                <f:setPropertyActionListener value="#{null}" target="#{roleFormDialog.model}" />
+                                <p:ajax event="dialogReturn" listener="#{rolesView.reloadFilterReset}" update=":rolesPermissionsForm:rolesListPanel" />
+                            </p:commandButton>
+                        </div>
+                        <p:inputText id="searchRoleTerm" required="false"
+                                     placeholder="Search for roles..."
+                                     value="#{rolesView.searchTerm}" style="width: 100%; margin-bottom: 10px;">
+                            <p:ajax event="keyup" listener="#{rolesView.reloadFilterReset}" update=":rolesPermissionsForm:rolesListPanel" />
+                        </p:inputText>
+
+                        <p:dataList id="rolesListPanel" value="#{rolesView.dataModels}" var="role" type="definition">
+                            <f:facet name="header">
+                                <h:outputText value="Roles" />
+                            </f:facet>
+                            <p:commandLink update=":rolesPermissionsForm:permissionPanel"
+                                           actionListener="#{rolesView.loadSelectedRole(role)}"
+                                           styleClass="p-d-flex p-jc-between p-ai-center p-py-2 p-px-3"
+                                           style="border-bottom: 1px solid var(--surface-d); text-decoration: none; color: inherit;">
+                                <div class="p-d-flex p-flex-column">
+                                    <h:outputText value="#{role.name}" style="font-weight: bold;"/>
+                                    <small class="p-text-muted">#{role.description}</small>
+                                </div>
+                                <i class="fa fa-lock"/>
+                                <p:ajax update=":rolesPermissionsForm:permissionPanel" listener="#{rolesView.loadSelectedRole(role)}"/>
+                            </p:commandLink>
+                        </p:dataList>
+
+                        <div class="p-mt-3">
+                            <p:commandButton value="Save Changes" icon="fa fa-save"
+                                             actionListener="#{rolesView.saveSelectedRolePermissions}"
+                                             update=":rolesPermissionsForm:messages"
+                                             styleClass="ui-button-primary"
+                                             rendered="#{rolesView.selectedRole != null}" />
                         </div>
                     </div>
                 </div>
-            </div>
 
-            <div class="p-grid ">
-                <div class="p-col-12">
+                <!-- Right Panel: Permissions Display and Management -->
+                <div class="p-col-12 p-md-8">
                     <div class="card">
-                        <p:dataTable id="rolesTable" var="model"
-                                     value="#{rolesView.dataModels}" widgetVar="rolesTable"
-                                     paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink}"
-                                     paginator="true" lazy="true"
-                                     rows="#{rolesView.maximumresultsPerpage}"
-                                     emptyMessage="#{rolesView.dataEmptyMessage}"
-                                     paginatorPosition="bottom" paginatorAlwaysVisible="false"
-                                     rowIndexVar="row" reflow="true" styleClass="TableAlgnment">
+                        <p:panel id="permissionPanel" style="min-height: 500px;">
                             <f:facet name="header">
-                                <div class="p-d-flex p-jc-between">
-                                    <div>
-                                        <span style="font-weight: bold">Roles</span>
-                                    </div>
-                                    <div>
-                                        <p:commandButton value="Add Role" process="@this"
-                                                         styleClass="ui-button-help"
-                                                         actionListener="#{roleFormDialog.show}">
-                                            <f:setPropertyActionListener value="#{null}"
-                                                                         target="#{roleFormDialog.model}" />
-                                            <p:ajax event="dialogReturn" listener="#{rolesView.reloadFilterReset}" update="rolesTable" />
-                                        </p:commandButton>
-                                    </div>
-                                </div>
+                                <h:outputText value="Permissions for: " rendered="#{rolesView.selectedRole != null}"/>
+                                <h:outputText value="#{rolesView.selectedRole.name}" style="font-weight: bold;" rendered="#{rolesView.selectedRole != null}"/>
+                                <h:outputText value="Select a role to view/manage permissions" rendered="#{rolesView.selectedRole == null}"/>
                             </f:facet>
-                            <p:column width="30" headerText="No.">
-                                <h:outputText value="#{row + 1}" />
-                            </p:column>
-                            <p:column>
-                                <f:facet name="header">
-                                    <h:outputText value="Name" />
-                                </f:facet>
-                                <h:outputText value="#{model.name}" />
-                            </p:column>
-                            <p:column>
-                                <f:facet name="header">
-                                    <h:outputText value="Description" />
-                                </f:facet>
-                                <h:outputText value="#{model.description}" />
-                            </p:column>
-                            <p:column style="text-align: center">
-                                <f:facet name="header">
-                                    <h:outputText value="Permisions" />
-                                </f:facet>
-                                <h:outputText value="#{model.permissions.size()}" />
-                            </p:column>
-                            <p:column style="text-align: center">
-                                <f:facet name="header">
-                                    <h:outputText value="Assign Permissions" />
-                                </f:facet>
-                                <p:commandLink id="viewpermissions" action="#{rolesView.redirectToPermissionsView()}"
-                                               value="View Permissions">
-                                    <f:setPropertyActionListener value="#{model}"
-                                                                 target="#{permissionView.selectedRole}" />
-                                </p:commandLink>
-                            </p:column>
-                            <p:column headerText="Action" exportable="false" width="150"
-                                      style="text-align: center">
 
-                                <p:commandButton icon="fa fa-edit" title="Edit role"
-                                                 styleClass="ui-button-help" immediate="true"
-                                                 actionListener="#{roleFormDialog.show}">
-                                    <f:setPropertyActionListener value="#{model}"
-                                                                 target="#{roleFormDialog.model}" />
-
-                                    <p:ajax event="dialogReturn" update="rolesTable" />
-                                </p:commandButton>
-
-                                <p:commandButton icon="fa fa-trash" title="Delete role"
-                                                 styleClass="ui-button-danger" style="margin-left: 5px"
-                                                 actionListener="#{rolesView.deleteSelectedRole(model)}" update="rolesView">
-                                    <p:confirm header="Confirmation"
-                                               message="You are about to delete a role. Do you wish to continue?"
-                                               icon="ui-icon-alert" />
-                                </p:commandButton>
-                            </p:column>
-                        </p:dataTable>
-                        <p:blockUI block="rolesView" trigger="searchBtn">
-                            <p:graphicImage value="/resources/images/workingicon.png" />
-                        </p:blockUI>
+                            <p:outputPanel rendered="#{rolesView.selectedRole != null}">
+                                <div class="p-text-center p-mb-3">
+                                    <h:outputText value="Full system access. Cannot be modified." style="color: red; font-style: italic;"/>
+                                </div>
+                                <p:selectManyCheckbox id="permissions-checkbox" value="#{rolesView.selectedPermissions}"
+                                                      converter="permissionConverter" layout="responsive" columns="2" styleClass="ui-fluid"
+                                                      disabled="#{rolesView.selectedRole.name == 'CEO'}">
+                                    <f:selectItems value="#{rolesView.groupedPermissions}" />
+                                    <p:ajax listener="#{rolesView.displaySelectedPermissions}" event="change" />
+                                </p:selectManyCheckbox>
+                            </p:outputPanel>
+                        </p:panel>
                     </div>
                 </div>
             </div>
 
-            <p:blockUI block="rolesView">
+            <p:blockUI block="rolesPermissionsForm">
                 <p:graphicImage value="/resources/images/workingicon.png" />
             </p:blockUI>
             <p:confirmDialog global="true">
-                <p:commandButton value="Yes" type="button"
-                                 styleClass="ui-confirmdialog-yes" icon="fa fa-thumbs-up" />
-                <p:commandButton value="No" type="button"
-                                 styleClass="ui-confirmdialog-no" icon="fa fa-thumbs-down" />
+                <p:commandButton value="Yes" type="button" styleClass="ui-confirmdialog-yes" icon="fa fa-thumbs-up" />
+                <p:commandButton value="No" type="button" styleClass="ui-confirmdialog-no" icon="fa fa-thumbs-down" />
             </p:confirmDialog>
         </h:form>
     </ui:define>


### PR DESCRIPTION
Refactors the roles management view to provide a two-panel layout: a roles list on the left and grouped permissions management on the right. Introduces grouped permission selection by category, updates the Java backing bean to support grouped permissions, and streamlines the process for assigning permissions to roles. Also updates sidebar navigation to combine 'Roles' and 'Permissions' into a single entry and improves role creation and editing workflows.

 #### Description
=> Full details of the tasks in the PR
#### Type of change
=> Please select the relevant option
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others (cosmetics, styling, improvements)
- [ ] This change requires a documentation update
#### How Has This Been Tested?

#### How can this be Tested?
=> Include the steps needed to test this PR
#### Any background context you want to add
