### PR TITLE
Add team detail view for teams

### DIFF
--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/security/HyperLinks.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/security/HyperLinks.java
@@ -20,6 +20,7 @@ public class HyperLinks {
     public static final String DEPARTMENT_FORM_DIALOG = "/pages/department/DepartmentFormDialog.xhtml";
     public static final String TEAMS_VIEW = "/pages/teams/TeamsView.xhtml?faces-redirect=true";
     public static final String TEAM_FORM_DIALOG = "/pages/teams/TeamFormDialog.xhtml?faces-redirect=true";
+    public static final String TEAM_DETAIL_VIEW = "/pages/teams/TeamDetailView.xhtml";
 
     public static final String SURVEY_CATEGORY_FORM_DIALOG = "/pages/OrganisationFit/SurveyCategoryFormDialog.xhtml";
     public static final String SURVEY_CATEGORY_VIEW = "/pages/OrganisationFit/SurveyCategoryView.xhtml?faces-redirect=true";

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/department/DepartmentDetailView.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/department/DepartmentDetailView.java
@@ -156,4 +156,14 @@ public class DepartmentDetailView {
     public boolean hasUnassignedMembers() {
         return unassignedMembers != null && !unassignedMembers.isEmpty();
     }
+
+    public String navigateToTeamDetail(Team team) {
+        if (team != null) {
+            // Store the selected team in flash scope for the detail view
+            javax.faces.context.FacesContext.getCurrentInstance()
+                    .getExternalContext().getFlash().put("selectedTeamId", team.getId());
+            return HyperLinks.TEAM_DETAIL_VIEW + "?faces-redirect=true";
+        }
+        return null;
+    }
 }

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/teams/TeamDetailView.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/teams/TeamDetailView.java
@@ -1,0 +1,95 @@
+package org.pahappa.systems.kpiTracker.views.teams;
+
+import com.googlecode.genericdao.search.Search;
+import lombok.Getter;
+import lombok.Setter;
+import org.pahappa.systems.kpiTracker.core.services.TeamService;
+import org.pahappa.systems.kpiTracker.core.services.AssignedUserService;
+import org.pahappa.systems.kpiTracker.models.team.Team;
+import org.pahappa.systems.kpiTracker.security.HyperLinks;
+import org.sers.webutils.model.RecordStatus;
+import org.sers.webutils.model.security.User;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.ViewScoped;
+import java.util.ArrayList;
+import java.util.List;
+
+@ManagedBean(name = "teamDetailView")
+@Getter
+@Setter
+@ViewScoped
+public class TeamDetailView {
+
+    private TeamService teamService;
+    private AssignedUserService assignedUserService;
+
+    private Team team;
+    private String teamId;
+    private List<User> teamMembers;
+
+    @PostConstruct
+    public void init() {
+        try {
+            this.teamService = ApplicationContextProvider.getBean(TeamService.class);
+            this.assignedUserService = ApplicationContextProvider.getBean(AssignedUserService.class);
+
+            javax.faces.context.FacesContext facesContext = javax.faces.context.FacesContext.getCurrentInstance();
+            if (facesContext != null) {
+                Object flashTeamId = facesContext.getExternalContext().getFlash().get("selectedTeamId");
+                if (flashTeamId != null) {
+                    this.teamId = flashTeamId.toString();
+                } else {
+                    String paramTeamId = facesContext.getExternalContext().getRequestParameterMap()
+                            .get("teamId");
+                    if (paramTeamId != null) {
+                        this.teamId = paramTeamId;
+                    }
+                }
+            }
+
+            if (this.teamId != null && !this.teamId.trim().isEmpty()) {
+                loadTeamDetails();
+            }
+
+        } catch (Exception e) {
+            System.err.println("Error initializing TeamDetailView: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    private void loadTeamDetails() {
+        try {
+            this.team = teamService.getInstanceByID(this.teamId);
+            if (this.team == null) {
+                System.err.println("Team not found with ID: " + this.teamId);
+                return;
+            }
+            this.teamMembers = new ArrayList<>(this.team.getMembers()); // Convert Set to List
+        } catch (Exception e) {
+            System.err.println("Error loading team details: " + e.getMessage());
+            e.printStackTrace();
+            this.teamMembers = new ArrayList<>();
+        }
+    }
+
+    public String navigateToDepartmentDetailFromTeam() {
+        // If you want to go back to all teams, not just department-filtered teams
+        return HyperLinks.DEPARTMENT_DETAIL_VIEW + "?faces-redirect=true";
+    }
+
+//    public String navigateToDepartmentDetailFromTeam() {
+//        if (team != null && team.getDepartment() != null) {
+//            javax.faces.context.FacesContext.getCurrentInstance()
+//                    .getExternalContext().getFlash().put("selectedDepartmentId", team.getDepartment().getId());
+//            return HyperLinks.DEPARTMENT_DETAIL_VIEW + "?faces-redirect=true";
+//        }
+//        return HyperLinks.DEPARTMENT_VIEW + "?faces-redirect=true"; // Fallback
+//    }
+
+    public boolean hasMembers() {
+        return teamMembers != null && !teamMembers.isEmpty();
+    }
+}

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/department/DepartmentDetailView.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/department/DepartmentDetailView.xhtml
@@ -103,7 +103,7 @@
                                                         <div>
                                                             <p:commandButton value="View Details" icon="fa fa-eye"
                                                                 styleClass="ui-button-outlined ui-button-sm"
-                                                                action="#{teamDetailView.navigateToTeamDetail(team)}" />
+                                                                action="#{departmentDetailView.navigateToTeamDetail(team)}"/>
                                                         </div>
                                                     </div>
                                                 </div>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/teams/TeamDetailView.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/teams/TeamDetailView.xhtml
@@ -1,0 +1,123 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui"
+                template="/pages/californiatemplate/template.xhtml">
+
+    <ui:define name="content">
+        <div class="ui-g ui-fluid">
+            <div class="ui-g-12">
+                <h:form id="teamDetailForm">
+
+                    <div class="p-mb-4">
+                        <div style="margin-bottom: 15px;">
+                            <p:commandButton icon="fa fa-arrow-left"
+                                             action="#{teamDetailView.navigateToDepartmentDetailFromTeam}"
+                                             styleClass="ui-button-icon-only ui-button-rounded ui-button-outlined"
+                                             style="width: 35px; height: 35px; border-radius: 50%; background: white; border: 1px solid #ddd; box-shadow: 0 2px 4px rgba(0,0,0,0.1);"
+                                             title="Back to Department" />
+                        </div>
+
+                        <div class="p-d-flex p-ai-center">
+                            <i class="fa fa-users p-mr-3" style="font-size: 2rem; color: #007bff;"> </i>
+                            <h2 style="margin: 0; color: #333;">#{teamDetailView.team.teamName}</h2>
+                        </div>
+                        <p style="margin-top: 5px; color: #666;">Part of: #{teamDetailView.team.department.name}</p>
+                    </div>
+
+                    <div class="p-grid">
+                        <!-- Left Column - Team Details -->
+                        <div class="p-col-12 p-md-4">
+                            <div class="card" style="height: 100%;">
+                                <div class="card-header">
+                                    <h5 style="margin: 0; font-weight: 600;">Team Details</h5>
+                                </div>
+                                <div class="card-body">
+                                    <div class="p-mb-3">
+                                        <strong>Lead:</strong>
+                                        <span class="p-ml-2">
+                                            #{teamDetailView.team.teamLead != null ?
+                                                    teamDetailView.team.teamLead.fullName : 'No Lead Assigned'}
+                                        </span>
+                                    </div>
+
+                                    <div class="p-mb-3">
+                                        <strong>Department:</strong>
+                                        <span class="p-ml-2">
+                                            #{teamDetailView.team.department.name}
+                                        </span>
+                                    </div>
+
+                                    <div class="p-mb-3">
+                                        <strong>Description:</strong>
+                                        <p style="color: #666; line-height: 1.6; margin: 0;">
+                                            #{teamDetailView.team.description != null ?
+                                                    teamDetailView.team.description : 'No description available.'}
+                                        </p>
+                                    </div>
+
+                                    <div class="p-mt-4">
+                                        <p:commandButton value="Edit Team" icon="fa fa-pencil"
+                                                         actionListener="#{teamFormDialog.show}"
+                                                         oncomplete="PF('teamFormDialogWidget').show()"
+                                                         styleClass="ui-button-primary">
+                                            <f:setPropertyActionListener value="#{teamDetailView.team}"
+                                                                         target="#{teamFormDialog.model}" />
+                                            <p:ajax event="dialogReturn" update="teamDetailForm" />
+                                        </p:commandButton>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Right Column - Team Members -->
+                        <div class="p-col-12 p-md-8">
+                            <div class="card">
+                                <div class="card-header">
+                                    <h5 style="margin: 0; font-weight: 600;">
+                                        Team Members (#{teamDetailView.teamMembers.size()})
+                                    </h5>
+                                </div>
+                                <div class="card-body">
+                                    <ui:fragment rendered="#{teamDetailView.hasMembers()}">
+                                        <div class="member-list">
+                                            <ui:repeat value="#{teamDetailView.teamMembers}" var="member" varStatus="status">
+                                                <div class="member-item p-p-3 p-mb-2"
+                                                     style="border: 1px solid #e9ecef; border-radius: 8px; background: #f8f9fa;">
+                                                    <div class="p-d-flex p-jc-between p-ai-center">
+                                                        <div>
+                                                            <span style="color: #666; margin-right: 10px;">#{status.index + 1}.</span>
+                                                            <span style="font-weight: 500; color: #333;">#{member.fullName}</span>
+                                                            <ui:fragment rendered="#{member.id == teamDetailView.team.teamLead.id}">
+                                                                <span class="p-ml-2 ui-tag ui-tag-info">Lead</span>
+                                                            </ui:fragment>
+                                                        </div>
+                                                        <!-- You can add actions here if needed, e.g., remove member -->
+                                                    </div>
+                                                </div>
+                                            </ui:repeat>
+                                        </div>
+                                    </ui:fragment>
+                                    <ui:fragment rendered="#{not teamDetailView.hasMembers()}">
+                                        <div class="p-text-center p-p-4">
+                                            <i class="fa fa-users"
+                                               style="font-size: 3rem; color: #ccc; margin-bottom: 1rem;">
+                                            </i>
+                                            <p style="color: #666; margin: 0;">No members assigned to this team.</p>
+                                        </div>
+                                    </ui:fragment>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Include team form dialog for editing -->
+                    <ui:include src="/pages/teams/TeamFormDialog.xhtml" />
+
+                </h:form>
+            </div>
+        </div>
+    </ui:define>
+
+</ui:composition>


### PR DESCRIPTION
Introduces TeamDetailView Java class and corresponding XHTML page to display detailed information about a team, including its members and lead. Updates navigation from DepartmentDetailView to allow viewing team details, and adds a hyperlink constant for the new view.

 #### Description
=> Full details of the tasks in the PR
#### Type of change
=> Please select the relevant option
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others (cosmetics, styling, improvements)
- [ ] This change requires a documentation update
#### How Has This Been Tested?

#### How can this be Tested?
=> Include the steps needed to test this PR
#### Any background context you want to add
